### PR TITLE
New park form

### DIFF
--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -12,3 +12,18 @@
   -moz-tab-size: 4;
   tab-size: 4;
 }
+
+.callout {
+  width: 800px;
+  margin: auto;
+  background-color: #DFEBD6;
+  color: #6b9947;
+}
+label{
+  color: #6b9947;
+}
+body {
+  background-color: #faf9e4;
+
+}
+

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -38,11 +38,11 @@ const App = (props) => {
           <h2>{greeting}</h2>
         </Route>
         <Route exact path="/parks" component={ParkList} />
+        <AuthenticatedRoute exact path="/parks/new" component={NewParkForm} user={currentUser} />
         <Route exact path="/parks/:id" component={ParkShow} />
         <Route exact path="/users/new" component={RegistrationForm} />
         <Route exact path="/user-sessions/new" component={SignInForm} />
         <AuthenticatedRoute exact path="/profile" component={UserProfile} user={currentUser} />
-        <AuthenticatedRoute exact path="/new" component={NewParkForm} user={currentUser} />
       </Switch>
     </Router>
   );

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -42,7 +42,7 @@ const App = (props) => {
         <Route exact path="/users/new" component={RegistrationForm} />
         <Route exact path="/user-sessions/new" component={SignInForm} />
         <AuthenticatedRoute exact path="/profile" component={UserProfile} user={currentUser} />
-        <AuthenticatedRoute exact path="/parks/new" component={NewParkForm} user={currentUser} />
+        <AuthenticatedRoute exact path="/new" component={NewParkForm} user={currentUser} />
       </Switch>
     </Router>
   );

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -9,6 +9,7 @@ import SignInForm from "./authentication/SignInForm";
 import TopBar from "./layout/TopBar";
 import UserProfile from "./UserProfile"
 import AuthenticatedRoute from "./authentication/AuthenticatedRoute"
+import NewParkForm from "./NewParkForm"
 
 const App = (props) => {
   const [currentUser, setCurrentUser] = useState(undefined);
@@ -37,6 +38,7 @@ const App = (props) => {
         <Route exact path="/users/new" component={RegistrationForm} />
         <Route exact path="/user-sessions/new" component={SignInForm} />
         <AuthenticatedRoute exact path="/profile" component={UserProfile} user={currentUser} />
+        <AuthenticatedRoute exact path="/parks/new" component={NewParkForm} user={currentUser} />
       </Switch>
     </Router>
   );

--- a/client/src/components/NewParkForm.js
+++ b/client/src/components/NewParkForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import translateServerErrors from "../services/translateServerErrors.js"
 import FormError from "./layout/FormError.js"
+import {Redirect} from "react-router-dom"
 
 const NewParkForm = (props) => {
 

--- a/client/src/components/NewParkForm.js
+++ b/client/src/components/NewParkForm.js
@@ -39,14 +39,11 @@ const NewParkForm = (props) => {
         const body = await response.json();
         console.log("posted successfully", body)
         setShouldRedirect(true)
-       
       }
     } catch (error) {
       console.error(`Error in fetch: ${error.message}`);
     }
   };
-
-
 
   const handleInputChange = event => {
     setNewPark({
@@ -54,6 +51,7 @@ const NewParkForm = (props) => {
       [event.currentTarget.name]: event.currentTarget.value
     })
   }
+
   const handleSubmit = event => {
     event.preventDefault()
     postPark(newPark)
@@ -69,7 +67,6 @@ const NewParkForm = (props) => {
       picture: "",
     })
   }
-
 
   if (shouldRedirect) {
     return <Redirect to="/parks" />

--- a/client/src/components/NewParkForm.js
+++ b/client/src/components/NewParkForm.js
@@ -1,0 +1,152 @@
+import React, { useState } from "react"
+import translateServerErrors from "../services/translateServerErrors.js"
+import FormError from "./layout/FormError.js"
+
+const NewParkForm = (props) => {
+
+  const [newPark, setNewPark] = useState({
+    name: "",
+    description: "",
+    location: "",
+    rating: "",
+    picture: "",
+  })
+
+  const [errors, setErrors] = useState([])
+  const [shouldRedirect, setShouldRedirect] = useState(false)
+
+  const postPark = async (newParkData) => {
+    try {
+      const response = await fetch(`/api/v1/parks`, {
+        method: "POST",
+        headers: new Headers({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify(newParkData),
+      });
+      if (!response.ok) {
+        if (response.status === 422) {
+          const body = await response.json();
+          const newErrors = translateServerErrors(body.errors);
+          return setErrors(newErrors);
+        } else {
+          const errorMessage = `${response.status} (${response.statusText})`;
+          const error = new Error(errorMessage);
+          throw error;
+        }
+      } else {
+        const body = await response.json();
+        console.log("posted successfully", body)
+        setShouldRedirect(true)
+       
+      }
+    } catch (error) {
+      console.error(`Error in fetch: ${error.message}`);
+    }
+  };
+
+
+
+  const handleInputChange = event => {
+    setNewPark({
+      ...newPark,
+      [event.currentTarget.name]: event.currentTarget.value
+    })
+  }
+  const handleSubmit = event => {
+    event.preventDefault()
+    postPark(newPark)
+    clearForm()
+  }
+
+  const clearForm = () => {
+    setNewPark({
+      name: "",
+      description: "",
+      location: "",
+      rating: "",
+      picture: "",
+    })
+  }
+
+
+  if (shouldRedirect) {
+    return <Redirect to="/parks" />
+  }
+
+  return (
+    <div className="callout">
+      <h1>Add a Park to this Page</h1>
+      <form onSubmit={handleSubmit} >
+        <label>
+          Name:
+          <input
+            type="text"
+            name="name"
+            placeholder="Name"
+            onChange={handleInputChange}
+            value={newPark.name}
+          />
+          <FormError error={errors.name} />
+        </label>
+
+        <label>
+          Description (Optional):
+          <input
+            type="text"
+            name="description"
+            placeholder="Description"
+            onChange={handleInputChange}
+            value={newPark.description}
+          />
+        </label>
+
+        <label>
+          Location:
+          <input
+            type="text"
+            name="location"
+            placeholder="Location"
+            onChange={handleInputChange}
+            value={newPark.location}
+          />
+          <FormError error={errors.location} />
+        </label>
+
+        <label>
+          Rating:
+          <select name="rating" onChange={handleInputChange} value={newPark.rating}> 
+            <option value=" "></option>
+            <option value="1">1 Star</option>
+            <option value="1.5">1.5 Stars</option>
+            <option value="2">2 Stars </option>
+            <option value="2.5">2.5 Stars </option>
+            <option value="3">3 Stars </option>
+            <option value="3.5">3.5 Stars </option>
+            <option value="4">4 Stars </option>
+            <option value="4.5">4.5 Stars </option>
+            <option value="5">5 Stars </option>
+          </select>
+          <FormError error={errors.rating} />
+        </label>
+
+        <label>
+          Picture:
+          <input
+            type="text"
+            name="picture"
+            placeholder="Picture"
+            onChange={handleInputChange}
+            value={newPark.picture}
+          />
+        </label>
+
+        <div className="button-group">
+          <input className="button" type="submit" value="Submit" />
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default NewParkForm

--- a/client/src/components/UserProfile.js
+++ b/client/src/components/UserProfile.js
@@ -8,6 +8,8 @@ const UserProfile = (props) => {
   return (
     <div>
       <h1>Parkview profile for {userName}</h1>
+      <Link to="/parks/new">Add a new Park!</Link>
+
     </div>
   )
 }

--- a/client/src/components/layout/ParkTile.js
+++ b/client/src/components/layout/ParkTile.js
@@ -8,10 +8,10 @@ const ParkTile = (props) => {
       <Link to={`/parks/${id}`}>
         <h3>{name}</h3>
       </Link>
+      <img src={picture}/>
       <h5>{location}</h5>
       <p>{description}</p>
       <p>{rating}</p>
-      <p>{picture}</p>
     </div>
   )
 }

--- a/client/src/components/layout/TopBar.js
+++ b/client/src/components/layout/TopBar.js
@@ -32,7 +32,7 @@ const TopBar = ({ user }) => {
         <ul className="menu">
           <li className="menu-text">App</li>
           <li>
-            <Link to="/">Home</Link>
+            <Link to="/parks">Home</Link>
           </li>
         </ul>
       </div>

--- a/client/src/components/layout/TopBar.js
+++ b/client/src/components/layout/TopBar.js
@@ -19,7 +19,7 @@ const TopBar = ({ user }) => {
     <Link to="/profile">Profile Page</Link>
     </li>,
     <li>
-      <Link to="/new">Add a new Park!</Link>
+      <Link to="/parks/new">Add a new Park!</Link>
     </li>,
     <li key="sign-out">
       <SignOutButton />

--- a/client/src/components/layout/TopBar.js
+++ b/client/src/components/layout/TopBar.js
@@ -19,7 +19,7 @@ const TopBar = ({ user }) => {
     <Link to="/profile">Profile Page</Link>
     </li>,
     <li>
-      <Link to="/parks/new">Add a new Park!</Link>
+      <Link to="/new">Add a new Park!</Link>
     </li>,
     <li key="sign-out">
       <SignOutButton />

--- a/client/src/components/layout/TopBar.js
+++ b/client/src/components/layout/TopBar.js
@@ -18,6 +18,9 @@ const TopBar = ({ user }) => {
     <li key="profile">
     <Link to="/profile">Profile Page</Link>
     </li>,
+    <li>
+      <Link to="/parks/new">Add a new Park!</Link>
+    </li>,
     <li key="sign-out">
       <SignOutButton />
     </li>

--- a/client/src/services/translateServerErrors.js
+++ b/client/src/services/translateServerErrors.js
@@ -1,0 +1,17 @@
+import _ from 'lodash'
+let translateServerErrors = (errors) => {
+  let serializedErrors = {}
+
+  Object.keys(errors).forEach((key) => {
+    const messages = errors[key].map((error) => {
+      const field = _.startCase(key)
+      serializedErrors = {
+        ...serializedErrors,
+        [field]: error.message
+      }
+    })
+  });
+  return serializedErrors
+};
+
+export default translateServerErrors;

--- a/server/src/db/migrations/20210127101731_createParks.cjs
+++ b/server/src/db/migrations/20210127101731_createParks.cjs
@@ -12,7 +12,7 @@ exports.up = async (knex) => {
     table.string("location").notNullable()
     table.string("description")
     table.float("rating").notNullable()
-    table.string("picture")
+    table.string("picture", 1000000)
     table.timestamp("createdAt").notNullable().defaultTo(knex.fn.now())
     table.timestamp("updatedAt").notNullable().defaultTo(knex.fn.now())
 

--- a/server/src/models/Park.js
+++ b/server/src/models/Park.js
@@ -19,7 +19,7 @@ class Park extends Model {
       location: {type: "string"},
       description: {type: "string"},
       rating: {type: ["string", "float"]},
-      picture: {type: ["string"]}
+      picture: {type: "string"}
     }
   }
 }

--- a/server/src/routes/api/v1/parksRouter.js
+++ b/server/src/routes/api/v1/parksRouter.js
@@ -15,20 +15,6 @@ parksRouter.get("/", async (req, res) => {
   }
 })
 
-parksRouter.post("/", async (req, res) => {
-  const { body } = req
-  const formInput = cleanUserInput(body)
-  try{
-    const newPark = await Park.query().insertAndFetch(formInput)
-    return res.status(201).json({park: newPark})
-  }catch(error) {
-    if (error instanceof ValidationError) {
-      return res.status(422).json({ errors: error.data });
-    }
-    return res.status(500).json({errors: error})
-  }
-})
-
 parksRouter.get("/:id", async (req,res) => {
 const parkId = req.params.id;
   try {
@@ -39,4 +25,17 @@ const parkId = req.params.id;
   }
 })
 
+parksRouter.post("/", async (req, res) => {
+  const { body } = req
+  const formInput = cleanUserInput(body)
+  try {
+    const newPark = await Park.query().insertAndFetch(formInput)
+    return res.status(201).json({park: newPark})
+  } catch(error) {
+    if (error instanceof ValidationError) {
+      return res.status(422).json({ errors: error.data });
+    }
+    return res.status(500).json({errors: error})
+  }
+})
 export default parksRouter 

--- a/server/src/routes/api/v1/parksRouter.js
+++ b/server/src/routes/api/v1/parksRouter.js
@@ -1,6 +1,8 @@
 import express from "express"
 import Park from "../../../models/Park.js"
 import cleanUserInput from "../../../services/cleanUserInput.js"
+import objection from "objection"
+const { ValidationError } = objection
 
 const parksRouter = new express.Router();
 
@@ -20,12 +22,12 @@ parksRouter.post("/", async (req, res) => {
     const newPark = await Park.query().insertAndFetch(formInput)
     return res.status(201).json({park: newPark})
   }catch(error) {
+    if (error instanceof ValidationError) {
+      return res.status(422).json({ errors: error.data });
+    }
     return res.status(500).json({errors: error})
   }
-
 })
-
-
 
 parksRouter.get("/:id", async (req,res) => {
 const parkId = req.params.id;

--- a/server/src/routes/api/v1/parksRouter.js
+++ b/server/src/routes/api/v1/parksRouter.js
@@ -1,5 +1,6 @@
 import express from "express"
 import Park from "../../../models/Park.js"
+import cleanUserInput from "../../../services/cleanUserInput.js"
 
 const parksRouter = new express.Router();
 
@@ -11,5 +12,19 @@ parksRouter.get("/", async(req, res) => {
     return res.status(500).json({ errors: error })
   }
 })
+
+parksRouter.post("/", async (req, res) => {
+  const { body } = req
+  const formInput = cleanUserInput(body)
+  try{
+    const newPark = await Park.query().insertAndFetch(formInput)
+    return res.status(201).json({park: newPark})
+  }catch(error) {
+    return res.status(500).json({errors: error})
+  }
+
+})
+
+
 
 export default parksRouter 

--- a/server/src/routes/clientRouter.js
+++ b/server/src/routes/clientRouter.js
@@ -3,7 +3,7 @@ import getClientIndexPath from "../config/getClientIndexPath.js";
 
 const router = new express.Router();
 
-const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile"];
+const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile", "/parks/new"];
 router.get(clientRoutes, (req, res) => {
   res.sendFile(getClientIndexPath());
 });

--- a/server/src/routes/clientRouter.js
+++ b/server/src/routes/clientRouter.js
@@ -3,7 +3,7 @@ import getClientIndexPath from "../config/getClientIndexPath.js";
 
 const router = new express.Router();
 
-const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile", "/parks", "/parks/:id", "/new"];
+const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile", "/parks", "/parks/:id", "/parks/new"];
 router.get(clientRoutes, (req, res) => {
   res.sendFile(getClientIndexPath());
 });

--- a/server/src/routes/clientRouter.js
+++ b/server/src/routes/clientRouter.js
@@ -3,7 +3,7 @@ import getClientIndexPath from "../config/getClientIndexPath.js";
 
 const router = new express.Router();
 
-const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile", "/parks", "/parks/:id", "/parks/new"];
+const clientRoutes = ["/", "/user-sessions/new", "/users/new", "/profile", "/parks", "/parks/:id", "/new"];
 router.get(clientRoutes, (req, res) => {
   res.sendFile(getClientIndexPath());
 });

--- a/server/src/services/cleanUserInput.js
+++ b/server/src/services/cleanUserInput.js
@@ -1,0 +1,10 @@
+const cleanUserInput = formInput => {
+  Object.keys(formInput).forEach(field => {
+    if(formInput[field] === "") {
+      delete formInput[field]
+    }
+  })
+  return formInput
+}
+
+export default cleanUserInput


### PR DESCRIPTION
- Added 422 validation for backend
- Added a post route for /api/v1/parks/ to handle new park form post
- Added localhoust:3000/new to client router.  Changed from parks/new to /new since parks/new was confusing the router.
- Changed default length of our picture field from 256 to 1000000 to hold long image url addresses at the database level.
- Changed address for “Add New Park!” top bar to goto /new.
- Added image to ParkTile.js and removed the url from the tile.
- Changed AuthenticatedRoute from /parks/new to /new
